### PR TITLE
Reconnect when socket is disconnected by server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "phoenix_channels_client"
-version = "0.1.2"
+version = "0.2.0"
 rust-version = "1.64"
-authors = ["Paul Schoenfelder <paulschoenfelder@gmail.com>"]
+authors = ["Paul Schoenfelder <paulschoenfelder@gmail.com>", "Elle Imhoff <Kronic.Deth@gmail.com>"]
 description = "Provides an async-ready client for Phoenix Channels in Rust"
 repository = "https://github.com/liveviewnative/phoenix-channels"
 homepage = "https://github.com/liveviewnative/phoenix-channels"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ async fn main() {
     // URL with params for authentication
     let url = Url::parse_with_params(
         "ws://127.0.0.1:9002/socket/websocket",
-        &[("shared_secret", "supersecret")],
+        &[("shared_secret", "supersecret"), ("id", "user-id")],
     ).unwrap();
 
     // Create a socket

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -285,8 +285,6 @@ pub enum JoinError {
     ShuttingDown,
     #[error("channel already shutdown")]
     Shutdown,
-    #[error("server disconnected the socket")]
-    ServerDisconnected,
     #[error("socket was disconnect while channel was being joined")]
     SocketDisconnected,
     #[error("leaving channel while still waiting to see if join succeeded")]

--- a/src/channel/listener.rs
+++ b/src/channel/listener.rs
@@ -618,18 +618,16 @@ impl State {
                     Some(rejoin) => rejoin.wait(),
                 },
                 Connectivity::Disconnected(disconnected) => match disconnected {
-                    Disconnected::ServerDisconnected
-                    | Disconnected::Disconnect
-                    | Disconnected::Reconnect => self,
+                    Disconnected::Disconnect | Disconnected::Reconnect => self,
                     Disconnected::Shutdown => State::ShuttingDown,
                 },
             },
             State::WaitingToJoin | State::Left => match connectivity {
                 Connectivity::Connected => self,
                 Connectivity::Disconnected(disconnected) => match disconnected {
-                    Disconnected::ServerDisconnected
-                    | Disconnected::Disconnect
-                    | Disconnected::Reconnect => State::WaitingForSocketToConnect { rejoin: None },
+                    Disconnected::Disconnect | Disconnected::Reconnect => {
+                        State::WaitingForSocketToConnect { rejoin: None }
+                    }
                     Disconnected::Shutdown => State::ShuttingDown,
                 },
             },
@@ -648,8 +646,7 @@ impl State {
                         rejoin: Some(rejoin),
                     }
                 }
-                Connectivity::Disconnected(Disconnected::ServerDisconnected)
-                | Connectivity::Disconnected(Disconnected::Disconnect) => {
+                Connectivity::Disconnected(Disconnected::Disconnect) => {
                     State::WaitingForSocketToConnect { rejoin: None }
                 }
                 Connectivity::Disconnected(Disconnected::Shutdown) => State::ShuttingDown,
@@ -657,9 +654,7 @@ impl State {
             State::WaitingToRejoin { sleep, rejoin } => match connectivity {
                 Connectivity::Connected => State::WaitingToRejoin { sleep, rejoin },
                 Connectivity::Disconnected(disconnected) => match disconnected {
-                    Disconnected::ServerDisconnected | Disconnected::Disconnect => {
-                        State::WaitingForSocketToConnect { rejoin: None }
-                    }
+                    Disconnected::Disconnect => State::WaitingForSocketToConnect { rejoin: None },
                     Disconnected::Shutdown => State::ShuttingDown,
                     Disconnected::Reconnect => State::WaitingForSocketToConnect {
                         rejoin: Some(rejoin),
@@ -672,8 +667,7 @@ impl State {
                         rejoin: Some(joined.rejoin()),
                     }
                 }
-                Connectivity::Disconnected(Disconnected::ServerDisconnected)
-                | Connectivity::Disconnected(Disconnected::Disconnect) => {
+                Connectivity::Disconnected(Disconnected::Disconnect) => {
                     State::WaitingForSocketToConnect { rejoin: None }
                 }
                 Connectivity::Disconnected(Disconnected::Shutdown) => State::ShuttingDown,
@@ -687,9 +681,7 @@ impl State {
                     State::Left
                 }
                 Connectivity::Disconnected(disconnected) => match disconnected {
-                    Disconnected::ServerDisconnected | Disconnected::Disconnect => {
-                        State::WaitingForSocketToConnect { rejoin: None }
-                    }
+                    Disconnected::Disconnect => State::WaitingForSocketToConnect { rejoin: None },
                     Disconnected::Shutdown => State::ShuttingDown,
                     Disconnected::Reconnect => {
                         Self::send_to_channel_txs(channel_left_txs, Ok(()));

--- a/tests/support/test_server/lib/test_server/socket.ex
+++ b/tests/support/test_server/lib/test_server/socket.ex
@@ -5,12 +5,10 @@ defmodule TestServer.Socket do
   # List of exposed channels
   channel("channel:*", TestServer.Channel)
 
-  def connect(params, socket, _connect_info) do
-    case params["shared_secret"] do
-      "supersecret" -> {:ok, socket}
-      _ -> :error
-    end
+  def connect(%{"shared_secret" => "supersecret", "id" => id}, socket, _connect_info) do
+    {:ok, assign(socket, :id, id)}
   end
+  def connect(_, _, _), do: :error
 
-  def id(_socket), do: ""
+  def id(%Phoenix.Socket{assigns: %{id: id}}), do: "sockets:#{id}"
 end


### PR DESCRIPTION
Resolves #14

Always reconnect when disconnected by the server no matter the reason.  Only stay disconnected if the `Socket::disconnect` or `Socket::shutdown` methods are called.

This ensures that if the server disconnects all sockets by ID, such as security reasons (http://kronicdeth.github.io/routing-securely-with-phoenix-framework/#/compromise-recovery-evict-from-remote-shell, https://hexdocs.pm/phoenix/Phoenix.Socket.html#module-examples, and https://hexdocs.pm/phoenix/Phoenix.Socket.html#c:id/1) then the client will attempt to reconnect.