### PR TITLE
Status polling and broadcast methods for Socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "phoenix_channels_client"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "atomic-take",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "phoenix_channels_client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "atomic-take",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix_channels_client"
-version = "0.2.0"
+version = "0.3.0"
 rust-version = "1.64"
 authors = ["Paul Schoenfelder <paulschoenfelder@gmail.com>", "Elle Imhoff <Kronic.Deth@gmail.com>"]
 description = "Provides an async-ready client for Phoenix Channels in Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod channel;
 mod join_reference;
 mod message;
 mod reference;
-mod socket;
+pub mod socket;
 mod topic;
 
 pub use serde_json::Value;

--- a/src/socket/listener.rs
+++ b/src/socket/listener.rs
@@ -691,9 +691,11 @@ impl Listener {
                     }))
                 }
                 Err(error) => {
-                    debug!("Error connecting to {}: {}", self.url, error);
+                    let arc_error = Arc::new(error);
+                    debug!("Error connecting to {}: {}", self.url, arc_error);
+                    self.socket_status.error(arc_error.clone());
 
-                    Err((error.into(), reconnect))
+                    Err((arc_error.into(), reconnect))
                 }
             },
             Err(_) => Err((ConnectError::Timeout, reconnect)),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,14 +7,17 @@ use std::time::Duration;
 use phoenix_channels_client::{
     socket, CallError, ConnectError, Event, EventPayload, JoinError, Payload, Socket,
 };
-use serde_json::json;
+use serde_json::{json, Value};
 use tokio::time;
 
 use log::debug;
+use phoenix_channels_client::socket::Status;
 #[cfg(feature = "nightly")]
 use std::assert_matches::assert_matches;
 use std::io::ErrorKind;
 use tokio::time::{timeout, Instant};
+use tokio_tungstenite::tungstenite;
+use tokio_tungstenite::tungstenite::http::StatusCode;
 use tokio_tungstenite::tungstenite::Error;
 use url::Url;
 use uuid::Uuid;
@@ -41,7 +44,8 @@ async fn phoenix_channels_socket_status_test() {
         .is_test(true)
         .try_init();
 
-    let url = url();
+    let id = id();
+    let url = shared_secret_url(id);
     let socket = Socket::spawn(url).await.unwrap();
 
     assert_eq!(socket.status(), socket::Status::NeverConnected);
@@ -68,7 +72,8 @@ async fn phoenix_channels_socket_event_test() {
         .is_test(true)
         .try_init();
 
-    let url = url();
+    let id = id();
+    let url = shared_secret_url(id);
     let socket = Socket::spawn(url).await.unwrap();
 
     let mut statuses = socket.statuses();
@@ -79,7 +84,7 @@ async fn phoenix_channels_socket_event_test() {
             .await
             .unwrap()
             .unwrap(),
-        socket::Status::Connected
+        Ok(socket::Status::Connected)
     );
 
     let channel = socket.channel("channel:disconnect", None).await.unwrap();
@@ -96,14 +101,14 @@ async fn phoenix_channels_socket_event_test() {
             .await
             .unwrap()
             .unwrap(),
-        socket::Status::WaitingToReconnect
+        Ok(socket::Status::WaitingToReconnect)
     );
     assert_matches!(
         timeout(CONNECT_TIMEOUT, statuses.recv())
             .await
             .unwrap()
             .unwrap(),
-        socket::Status::Connected
+        Ok(socket::Status::Connected)
     );
 
     socket.disconnect().await.unwrap();
@@ -112,7 +117,7 @@ async fn phoenix_channels_socket_event_test() {
             .await
             .unwrap()
             .unwrap(),
-        socket::Status::Disconnected
+        Ok(socket::Status::Disconnected)
     );
 
     socket.shutdown().await.unwrap();
@@ -121,15 +126,103 @@ async fn phoenix_channels_socket_event_test() {
             .await
             .unwrap()
             .unwrap(),
-        socket::Status::ShuttingDown
+        Ok(socket::Status::ShuttingDown)
     );
     assert_matches!(
         timeout(CALL_TIMEOUT, statuses.recv())
             .await
             .unwrap()
             .unwrap(),
-        socket::Status::ShutDown
+        Ok(socket::Status::ShutDown)
     );
+}
+
+#[tokio::test]
+async fn phoenix_channels_socket_key_rotation_test() {
+    let _ = env_logger::builder()
+        .parse_default_env()
+        .filter_level(log::LevelFilter::Debug)
+        .is_test(true)
+        .try_init();
+
+    let id = id();
+    let shared_secret_url = shared_secret_url(id.clone());
+    let generate_secret_socket = connected_socket(shared_secret_url).await;
+
+    let generate_secret_channel = generate_secret_socket
+        .channel("channel:generate_secret", None)
+        .await
+        .unwrap();
+    generate_secret_channel.join(JOIN_TIMEOUT).await.unwrap();
+
+    let Payload::Value(value) = generate_secret_channel
+        .call("generate_secret", json!({}), CALL_TIMEOUT)
+        .await
+        .unwrap() else {panic!("secret not returned")};
+
+    let secret = if let Value::String(ref secret) = *value {
+        secret.to_owned()
+    } else {
+        panic!("secret ({:?}) is not a string", value);
+    };
+
+    let secret_url = secret_url(id, secret);
+    let secret_socket = connected_socket(secret_url).await;
+
+    let secret_channel = secret_socket.channel("channel:secret", None).await.unwrap();
+    secret_channel.join(JOIN_TIMEOUT).await.unwrap();
+
+    secret_channel
+        .call("delete_secret", json!({}), CALL_TIMEOUT)
+        .await
+        .unwrap();
+    let payload = json_payload();
+
+    let mut statuses = secret_socket.statuses();
+
+    secret_channel
+        .call("socket_disconnect", json!({}), CALL_TIMEOUT)
+        .await
+        .unwrap_err();
+
+    debug!("Sending to check for reconnect");
+    assert_matches!(
+        secret_channel
+            .call(
+                "send_reply",
+                payload.clone(),
+                CONNECT_TIMEOUT + JOIN_TIMEOUT + CALL_TIMEOUT
+            )
+            .await,
+        Err(CallError::Timeout)
+    );
+
+    let mut reconnect_count = 0;
+
+    loop {
+        tokio::select! {
+            result  = timeout(CALL_TIMEOUT, statuses.recv()) => match result.unwrap().unwrap() {
+                Ok(Status::WaitingToReconnect) => {
+                    reconnect_count += 1;
+
+                    if reconnect_count > 5 {
+                        panic!("Waiting to reconnect {} times without sending error status", reconnect_count);
+                    } else {
+                        continue
+                    }
+                },
+                Err(ref web_socket_error) => match web_socket_error.as_ref() {
+                    tungstenite::Error::Http(response) => {
+                        assert_eq!(response.status(), StatusCode::from_u16(403).unwrap());
+
+                        break
+                    },
+                    web_socket_error => panic!("Unexpected web socket error: {:?}", web_socket_error)
+                }
+                result => panic!("Unexpected status: {:?}", result),
+            }
+        }
+    }
 }
 
 #[tokio::test]
@@ -149,7 +242,8 @@ async fn phoenix_channels_reconnect_test(event: &str) {
         .is_test(true)
         .try_init();
 
-    let url = url();
+    let id = id();
+    let url = shared_secret_url(id);
     let socket = connected_socket(url).await;
 
     let channel = socket
@@ -211,7 +305,8 @@ async fn phoenix_channels_join_payload_test(subtopic: &str, payload: Payload) {
         .is_test(true)
         .try_init();
 
-    let url = url();
+    let id = id();
+    let url = shared_secret_url(id);
     let socket = connected_socket(url).await;
     let topic = format!("channel:join:payload:{}", subtopic);
 
@@ -243,7 +338,8 @@ async fn phoenix_channels_join_error_test(subtopic: &str, payload: Payload) {
         .is_test(true)
         .try_init();
 
-    let url = url();
+    let id = id();
+    let url = shared_secret_url(id);
     let socket = connected_socket(url).await;
 
     let topic = format!("channel:error:{}", subtopic);
@@ -274,7 +370,8 @@ async fn phoenix_channels_broadcast_test(subtopic: &str, payload: Payload) {
         .is_test(true)
         .try_init();
 
-    let url = url();
+    let id = id();
+    let url = shared_secret_url(id);
     let receiver_client = connected_socket(url.clone()).await;
 
     let topic = format!("channel:broadcast:{}", subtopic);
@@ -335,7 +432,9 @@ async fn phoenix_channels_call_test(subtopic: &str, payload: Payload) {
         .filter_level(log::LevelFilter::Debug)
         .is_test(true)
         .try_init();
-    let url = url();
+
+    let id = id();
+    let url = shared_secret_url(id);
     let socket = connected_socket(url).await;
 
     let topic = format!("channel:call:{}", subtopic);
@@ -367,7 +466,9 @@ async fn phoenix_channels_call_error_test(subtopic: &str, payload: Payload) {
         .filter_level(log::LevelFilter::Debug)
         .is_test(true)
         .try_init();
-    let url = url();
+
+    let id = id();
+    let url = shared_secret_url(id);
     let socket = connected_socket(url).await;
 
     let topic = format!("channel:raise:{}", subtopic);
@@ -399,7 +500,9 @@ async fn phoenix_channels_cast_error_test(subtopic: &str, payload: Payload) {
         .filter_level(log::LevelFilter::Debug)
         .is_test(true)
         .try_init();
-    let url = url();
+
+    let id = id();
+    let url = shared_secret_url(id);
     let socket = connected_socket(url).await;
 
     let topic = format!("channel:raise:{}", subtopic);
@@ -417,11 +520,15 @@ async fn connected_socket(url: Url) -> Arc<Socket> {
 
     if let Err(connect_error) = socket.connect(CONNECT_TIMEOUT).await {
         match connect_error {
-            ConnectError::WebSocketError(Error::Io(io_error)) => {
-                if io_error.kind() == ErrorKind::ConnectionRefused {
-                    panic!("Phoenix server not started. Run: cd tests/support/test_server && iex -S mix")
+            ConnectError::WebSocketError(ref web_socket_error) => {
+                if let Error::Io(io_error) = web_socket_error.as_ref() {
+                    if io_error.kind() == ErrorKind::ConnectionRefused {
+                        panic!("Phoenix server not started. Run: cd tests/support/test_server && iex -S mix")
+                    } else {
+                        panic!("{:?}", io_error)
+                    }
                 } else {
-                    panic!("{:?}", io_error)
+                    panic!("{:?}", web_socket_error)
                 }
             }
             _ => panic!("{:?}", connect_error),
@@ -431,20 +538,27 @@ async fn connected_socket(url: Url) -> Arc<Socket> {
     socket
 }
 
-fn url() -> Url {
+fn shared_secret_url(id: String) -> Url {
     Url::parse_with_params(
         format!("ws://{HOST}:9002/socket/websocket").as_str(),
-        &[
-            ("shared_secret", "supersecret"),
-            (
-                "id",
-                Uuid::new_v4()
-                    .hyphenated()
-                    .encode_upper(&mut Uuid::encode_buffer()),
-            ),
-        ],
+        &[("shared_secret", "supersecret".to_string()), ("id", id)],
     )
     .unwrap()
+}
+
+fn secret_url(id: String, secret: String) -> Url {
+    Url::parse_with_params(
+        format!("ws://{HOST}:9002/socket/websocket").as_str(),
+        &[("id", id), ("secret", secret)],
+    )
+    .unwrap()
+}
+
+fn id() -> String {
+    Uuid::new_v4()
+        .hyphenated()
+        .encode_upper(&mut Uuid::encode_buffer())
+        .to_string()
 }
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);

--- a/tests/support/test_server/lib/test_server/application.ex
+++ b/tests/support/test_server/lib/test_server/application.ex
@@ -10,6 +10,7 @@ defmodule TestServer.Application do
     children = [
       {Phoenix.PubSub, [adapter: Phoenix.PubSub.PG2, name: TestServer.PubSub]},
       TestServer.Endpoint,
+      TestServer.Secret
       # Starts a worker by calling: TestServer.Worker.start_link(arg)
       # {TestServer.Worker, arg}
     ]

--- a/tests/support/test_server/lib/test_server/secret.ex
+++ b/tests/support/test_server/lib/test_server/secret.ex
@@ -1,0 +1,48 @@
+defmodule TestServer.Secret do
+  use GenServer
+
+  def generate(id) do
+    GenServer.call(__MODULE__, {:generate, id})
+  end
+
+  def check(id, secret) do
+    GenServer.call(__MODULE__, {:check, id, secret})
+  end
+
+  def delete(id, secret) do
+    GenServer.call(__MODULE__, {:delete, id, secret})
+  end
+
+  def start_link([]) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init([]) do
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_call({:generate, id}, _from, state) do
+    secret =
+      20
+      |> :crypto.strong_rand_bytes()
+      |> Base.encode64()
+
+    {:reply, secret, Map.put(state, id, secret)}
+  end
+
+  def handle_call({:check, id, secret}, _from, state) do
+    case state do
+      %{^id => ^secret} -> {:reply, :ok, state}
+      _ -> {:reply, :error, state}
+    end
+  end
+
+  def handle_call({:delete, id, secret}, _from, state) do
+    case state do
+      %{^id => ^secret} -> {:reply, :ok, Map.delete(state, id)}
+      _ -> {:reply, :error, state}
+    end
+  end
+end

--- a/tests/support/test_server/lib/test_server/socket.ex
+++ b/tests/support/test_server/lib/test_server/socket.ex
@@ -8,6 +8,12 @@ defmodule TestServer.Socket do
   def connect(%{"shared_secret" => "supersecret", "id" => id}, socket, _connect_info) do
     {:ok, assign(socket, :id, id)}
   end
+  def connect(%{"id" => id, "secret" => secret}, socket, _connect_info) do
+    case TestServer.Secret.check(id, secret) do
+      :ok -> {:ok, assign(socket, %{id: id, secret: secret})}
+      :error -> :error
+    end
+  end
   def connect(_, _, _), do: :error
 
   def id(%Phoenix.Socket{assigns: %{id: id}}), do: "sockets:#{id}"


### PR DESCRIPTION
Resolves #20

Adds methods to poll for the socket status and to subscribe to broadcasts of the status changes.  The broadcast also includes `tungstenite::Error` when the reconnect fails, so subscribers can see if their authorization is no longer valid.