### PR TITLE
Return CallError::Reply from Channel::call if server :reply is :error or {:error, term()}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "phoenix_channels_client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "atomic-take",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix_channels_client"
-version = "0.3.0"
+version = "0.4.0"
 rust-version = "1.64"
 authors = ["Paul Schoenfelder <paulschoenfelder@gmail.com>", "Elle Imhoff <Kronic.Deth@gmail.com>"]
 description = "Provides an async-ready client for Phoenix Channels in Rust"

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ async fn main() {
     channel.join(Duration::from_secs(15)).await.unwrap();
     
     // Send a message, waiting for a reply until timeout
-    let reply_payload = channel.call("send_reply", json!({ "name": "foo", "message": "hi"}), Duration::from_secs(5)).await.unwrap();
+    let reply_payload = channel.call("reply_ok_tuple", json!({ "name": "foo", "message": "hi"}), Duration::from_secs(5)).await.unwrap();
 
     // Send a message, not waiting for a reply
-    channel.cast("send_noreply", json!({ "name": "foo", "message": "jeez"})).await.unwrap();
+    channel.cast("noreply", json!({ "name": "foo", "message": "jeez"})).await.unwrap();
 
     // Leave the channel
     channel.leave().await.unwrap();

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -350,6 +350,8 @@ pub enum CallError {
     WebSocketError(tungstenite::Error),
     #[error("socket disconnected while waiting for reply")]
     SocketDisconnected,
+    #[error("error from server {0:?}")]
+    Reply(Payload),
 }
 impl From<mpsc::error::SendError<SendCommand>> for CallError {
     fn from(_: mpsc::error::SendError<SendCommand>) -> Self {

--- a/tests/support/test_server/.gitignore
+++ b/tests/support/test_server/.gitignore
@@ -24,3 +24,6 @@ test_server-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+/node_modules
+/package-lock.json

--- a/tests/support/test_server/lib/test_server/channel.ex
+++ b/tests/support/test_server/lib/test_server/channel.ex
@@ -35,25 +35,33 @@ defmodule TestServer.Channel do
     raise payload
   end
 
-  def handle_in("send_all" = event, payload, %Socket{topic: topic} = socket) do
+  def handle_in("reply_ok", _payload, socket) do
+    {:reply, :ok, socket}
+  end
+
+  def handle_in("reply_error", _payload, socket) do
+    {:reply, :error, socket}
+  end
+
+  def handle_in("reply_ok_tuple", payload, socket) do
+    {:reply, {:ok, payload}, socket}
+  end
+
+  def handle_in("reply_error_tuple", payload, socket) do
+    {:reply, {:error, payload}, socket}
+  end
+
+  def handle_in("broadcast" = event, payload, %Socket{topic: topic} = socket) do
     TestServer.Endpoint.broadcast!(topic, event, payload)
     {:reply, :ok, socket}
   end
 
-  def handle_in("send_join_payload", _payload, %Socket{assigns: %{payload: payload}} = socket) do
+  def handle_in("reply_ok_join_payload", _payload, %Socket{assigns: %{payload: payload}} = socket) do
     {:reply, {:ok, payload}, socket}
   end
 
-  def handle_in("send_reply", payload, socket) do
-    {:reply, {:ok, payload}, socket}
-  end
-
-  def handle_in("send_noreply", _payload, socket) do
+  def handle_in("noreply", _payload, socket) do
     {:noreply, socket}
-  end
-
-  def handle_in("send_error", _payload, socket) do
-    {:reply, :error, socket}
   end
 
   def handle_in("socket_disconnect", _payload, %Phoenix.Socket{id: id} = socket) do


### PR DESCRIPTION
Fixes #21