### PR TITLE
Send to channel txs for all connectivity changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix_channels_client"
-version = "0.4.0"
+version = "0.4.1"
 rust-version = "1.64"
 authors = ["Paul Schoenfelder <paulschoenfelder@gmail.com>", "Elle Imhoff <Kronic.Deth@gmail.com>"]
 description = "Provides an async-ready client for Phoenix Channels in Rust"


### PR DESCRIPTION
Fixes #23

Added send_to_channel_txs calls:
* For `Joining` => `WaitingForSocketToConnect`, send `SocketDisconnected` for all `channel_joined_txs`.
* For `Joining` => `Shutdown`, send `ShuttingDown` for all `channel_joined_txs`.
* For `Leaving` => *, send `Ok(())` for all `channel_left_txs` since in all cases the connectivity changed and so effectively left the channel on the server.