### PR TITLE
Only trigger on pull_request

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,6 @@
 name: linux
 
-on: [pull_request, push]
+on: pull_request
 
 env:
   RUSTDOCFLAGS: "-D warnings"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,6 @@
 name: macos
 
-on: [pull_request, push]
+on: pull_request
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/x86_64-apple-ios.yml
+++ b/.github/workflows/x86_64-apple-ios.yml
@@ -1,7 +1,7 @@
 # based on https://gist.github.com/learnopengles/60c945b92fbe60a0fecaa0143c35c4a for testing in simulator
 name: x86_64-apple-ios
 
-on: [pull_request, push]
+on: pull_request
 
 env:
   TOOLCHAIN: nightly

--- a/.github/workflows/x86_64-linux-android.yml
+++ b/.github/workflows/x86_64-linux-android.yml
@@ -1,7 +1,7 @@
 # based on https://github.com/xaynetwork/cargo_tai
 name: x86_64-linux-android
 
-on: [pull_request, push]
+on: pull_request
 
 env:
   ANDROID_COMMANDLINE_TOOLS_VERSION: 9477386


### PR DESCRIPTION
Fixes #48

Triggering on both push and pull_request caused double builds for PRs from the repo. `pull_request` is needed to trigger for builds from forks, so drop `push`.  This matches setup @KronicDeth has in her KronicDeth/intellij-elixir repo, where she can approve GitHub actions from outside forks.