### PR TITLE
Speed up android build

### DIFF
--- a/.github/workflows/x86_64-linux-android.yml
+++ b/.github/workflows/x86_64-linux-android.yml
@@ -188,7 +188,7 @@ jobs:
           ${ANDROID_HOME}/platform-tools/adb start-server
           echo "Starting Emulator"
           ${ANDROID_HOME}/emulator/emulator -avd AVD -netdelay none -netspeed full -no-boot-anim -no-window -noaudio -accel auto -verbose &
-          ${ANDROID_HOME}/platform-tools/adb wait-for-device
+          ${ANDROID_HOME}/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
           echo "Launching Test Server"
           cd tests/support/test_server && mix phx.server &
           while ! nc -z localhost 9002; do sleep 0.1; done

--- a/.github/workflows/x86_64-linux-android.yml
+++ b/.github/workflows/x86_64-linux-android.yml
@@ -187,7 +187,7 @@ jobs:
           echo "Starting ADB server"
           ${ANDROID_HOME}/platform-tools/adb start-server
           echo "Starting Emulator"
-          ${ANDROID_HOME}/emulator/emulator -avd AVD -netdelay none -netspeed full &
+          ${ANDROID_HOME}/emulator/emulator -avd AVD -netdelay none -netspeed full -no-boot-anim -no-window -noaudio -accel auto -verbose &
           ${ANDROID_HOME}/platform-tools/adb wait-for-device
           echo "Launching Test Server"
           cd tests/support/test_server && mix phx.server &


### PR DESCRIPTION
Fixes #51

* Turn off android simulator options not used for tests to speed up builds
  * -no-boot-anim
  * -no-window
  * -noaudio
  * -accel auto
  * -verbose
*  Use keyevent 82 (unlock device) to speed up wait-for-device