### PR TITLE
Changes for using uniffi bindings in liveview-native-core

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,6 @@ env:
 
 jobs:
   integration_tests:
-    # macos-*-xlarge is needed to get M1 chips - https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
     runs-on: self-hosted
 
     steps:
@@ -16,7 +15,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ env.TOOLCHAIN }}
           default: true
       - name: Set up Elixir
         run: brew install elixir
@@ -71,3 +70,32 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+  uniffi-check:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.TOOLCHAIN }}
+          default: true
+      - name: Cache Cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ github.workflow }}-${{ github.job }}-toolchain-${{ env.TOOLCHAIN }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build static library
+        run: cargo build --lib --release # For some unclear reason, the release build has better errors.
+      - name: Generate swift bindings
+        run: |
+          cargo run --bin uniffi-bindgen -- generate --library ./target/release/libphoenix_channels_client.dylib --out-dir ./binding-swift/ --language swift
+      - name: Generate kotlin bindings
+        run: |
+          cargo run --bin uniffi-bindgen -- generate --library ./target/release/libphoenix_channels_client.dylib --out-dir ./binding-kotlin/ --language kotlin
+      - name: check without uniffi feature
+        run: cargo check --no-default-features --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,19 +533,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "windows",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,29 +734,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
-name = "loom"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
-dependencies = [
- "cfg-if",
- "generator",
- "pin-utils",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,16 +801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,13 +826,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "oneshot"
-version = "0.1.6"
+name = "oneshot-uniffi"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6640c6bda7731b1fdbab747981a0f896dd1fedaf9f4a53fa237a04a84431f4"
-dependencies = [
- "loom",
-]
+checksum = "9ae4988774e7a7e6a0783d119bdc683ea8c1d01a24d4fff9b4bdc280e07bd99e"
 
 [[package]]
 name = "openssl"
@@ -923,12 +874,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1085,23 +1030,8 @@ checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1156,12 +1086,6 @@ checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
  "windows-sys 0.42.0",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1261,15 +1185,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -1392,16 +1307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,19 +1393,7 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1510,36 +1403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -1600,8 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi"
-version = "0.24.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=856f40207e9a736f79241246c42bdb90d5c8e894#856f40207e9a736f79241246c42bdb90d5c8e894"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21345172d31092fd48c47fd56c53d4ae9e41c4b1f559fb8c38c1ab1685fd919f"
 dependencies = [
  "anyhow",
  "camino",
@@ -1614,8 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.24.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=856f40207e9a736f79241246c42bdb90d5c8e894#856f40207e9a736f79241246c42bdb90d5c8e894"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd992f2929a053829d5875af1eff2ee3d7a7001cb3b9a46cc7895f2caede6940"
 dependencies = [
  "anyhow",
  "askama",
@@ -1637,8 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.24.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=856f40207e9a736f79241246c42bdb90d5c8e894#856f40207e9a736f79241246c42bdb90d5c8e894"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001964dd3682d600084b3aaf75acf9c3426699bc27b65e96bb32d175a31c74e9"
 dependencies = [
  "anyhow",
  "camino",
@@ -1647,8 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.24.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=856f40207e9a736f79241246c42bdb90d5c8e894#856f40207e9a736f79241246c42bdb90d5c8e894"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55137c122f712d9330fd985d66fa61bdc381752e89c35708c13ce63049a3002c"
 dependencies = [
  "quote",
  "syn",
@@ -1656,22 +1523,25 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.24.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=856f40207e9a736f79241246c42bdb90d5c8e894#856f40207e9a736f79241246c42bdb90d5c8e894"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6121a127a3af1665cd90d12dd2b3683c2643c5103281d0fed5838324ca1fad5b"
 dependencies = [
  "anyhow",
  "bytes",
  "camino",
  "log",
- "oneshot",
+ "once_cell",
+ "oneshot-uniffi",
  "paste",
  "static_assertions",
 ]
 
 [[package]]
 name = "uniffi_macros"
-version = "0.24.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=856f40207e9a736f79241246c42bdb90d5c8e894#856f40207e9a736f79241246c42bdb90d5c8e894"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11cf7a58f101fcedafa5b77ea037999b88748607f0ef3a33eaa0efc5392e92e4"
 dependencies = [
  "bincode",
  "camino",
@@ -1688,8 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.24.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=856f40207e9a736f79241246c42bdb90d5c8e894#856f40207e9a736f79241246c42bdb90d5c8e894"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dc8573a7b1ac4b71643d6da34888273ebfc03440c525121f1b3634ad3417a2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1699,8 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.24.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=856f40207e9a736f79241246c42bdb90d5c8e894#856f40207e9a736f79241246c42bdb90d5c8e894"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118448debffcb676ddbe8c5305fb933ab7e0123753e659a71dc4a693f8d9f23c"
 dependencies = [
  "anyhow",
  "camino",
@@ -1711,8 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.24.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=856f40207e9a736f79241246c42bdb90d5c8e894#856f40207e9a736f79241246c42bdb90d5c8e894"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "889edb7109c6078abe0e53e9b4070cf74a6b3468d141bdf5ef1bd4d1dc24a1c3"
 dependencies = [
  "anyhow",
  "uniffi_meta",
@@ -1751,12 +1624,6 @@ checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -1833,7 +1700,8 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=856f40207e9a736f79241246c42bdb90d5c8e894#856f40207e9a736f79241246c42bdb90d5c8e894"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
 dependencies = [
  "nom",
 ]
@@ -1868,15 +1736,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "uniffi-bindgen.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = []
+default = ["uniffi"]
 nightly = []
 native-tls = ["tokio-tungstenite/native-tls"]
 
@@ -48,7 +48,7 @@ strum_macros = "0.25.0"
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full", "tracing", "test-util"] }
 tokio-tungstenite = "0.21.0"
-uniffi = { version = "0.24.3", features = ["cli"], git = "https://github.com/mozilla/uniffi-rs.git", rev = "856f40207e9a736f79241246c42bdb90d5c8e894" }
+uniffi = { version = "0.25.3", features = ["cli"], optional = true}
 url = "2.5"
 uuid = { version = "1.6.1", features = ["v4"] }
 
@@ -57,4 +57,4 @@ chrono = "0.4.31"
 env_logger = "0.10"
 
 [build-dependencies]
-uniffi = { version = "0.24.3", features = ["build"], git = "https://github.com/mozilla/uniffi-rs.git", rev = "856f40207e9a736f79241246c42bdb90d5c8e894" }
+uniffi = { version = "0.25.3", features = ["build"], optional = true}

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    uniffi::generate_scaffolding("src/phoenix_channels_client.udl").unwrap();
-}

--- a/src/ffi/channel/statuses.rs
+++ b/src/ffi/channel/statuses.rs
@@ -8,11 +8,20 @@ use crate::ChannelStatus;
 
 /// Waits for [ChannelStatus] changes from the [Channel](crate::Channel).
 // Can't be generic because `uniffi` does not support generics
-#[derive(uniffi::Object)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Object)
+)]
 pub struct ChannelStatuses(
     observable_status::Statuses<rust::channel::Status, Arc<rust::message::Payload>>,
 );
-#[uniffi::export]
+/*
+ *TODO: Nested results do not work when running uniffi-bindgen on build library.
+#[cfg_attr(
+    feature = "uniffi",
+    uniffi::export,
+)]
+*/
 impl ChannelStatuses {
     /// Wait for next [ChannelStatus] when the [Channel::status](super::Channel::status) changes.
     pub async fn status(
@@ -35,7 +44,11 @@ impl From<observable_status::Statuses<rust::channel::Status, Arc<rust::message::
 }
 
 /// Errors when calling [Channel::join](super::Channel::join).
-#[derive(Clone, Debug, thiserror::Error, uniffi::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Error)
+)]
 pub enum ChannelStatusJoinError {
     /// The [Channel::payload](super::Channel::payload) was rejected when attempting to
     /// [Channel::join](super::Channel::join) or automatically rejoin

--- a/src/ffi/http.rs
+++ b/src/ffi/http.rs
@@ -12,7 +12,11 @@ use tokio_tungstenite::tungstenite::http::{
 };
 
 /// [http::error::Error], but with `uniffi` support
-#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error, uniffi::Error)]
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Error)
+)]
 pub enum HttpError {
     #[error("invalid status code")]
     StatusCode,
@@ -60,7 +64,11 @@ impl From<&TungsteniteError> for HttpError {
     }
 }
 
-#[derive(Copy, Clone, Debug, thiserror::Error, uniffi::Error)]
+#[derive(Copy, Clone, Debug, thiserror::Error)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Error)
+)]
 pub enum InvalidUri {
     #[error("invalid uri character")]
     InvalidUriChar,
@@ -87,7 +95,11 @@ pub enum InvalidUri {
 }
 
 /// [http::response::Response], but without the generics that `uniffi` does not support and with `uniffi` support
-#[derive(Clone, Debug, PartialEq, Eq, uniffi::Record)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Record)
+)]
 pub struct Response {
     pub status_code: u16,
     pub headers: HashMap<String, Vec<String>>,

--- a/src/ffi/http/parse.rs
+++ b/src/ffi/http/parse.rs
@@ -1,6 +1,10 @@
 /// [httparse::Error], but with `uniffi` support
 /// An error in parsing.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, thiserror::Error, uniffi::Error)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, thiserror::Error)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Error)
+)]
 pub enum HTTParseError {
     /// Invalid byte in header name.
     #[error("invalid header name")]

--- a/src/ffi/io/error.rs
+++ b/src/ffi/io/error.rs
@@ -1,7 +1,11 @@
 use std::io::ErrorKind;
 
 /// [std::io::Error] and [std::io::ErrorKind], but with `uniffi` support.
-#[derive(Clone, Debug, thiserror::Error, uniffi::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Error)
+)]
 pub enum IoError {
     /// An entity was not found, often a file.
     #[error("entity not found")]
@@ -216,7 +220,6 @@ pub enum IoError {
     /// [`ErrorKind`] variant in the future. It is not recommended to match
     /// an error against `Uncategorized`; use a wildcard match (`_`) instead.
 
-    #[doc(hidden)]
     #[error("uncategorized error")]
     Uncategorized,
 }
@@ -233,37 +236,17 @@ impl From<ErrorKind> for IoError {
             ErrorKind::PermissionDenied => Self::PermissionDenied,
             ErrorKind::ConnectionRefused => Self::ConnectionRefused,
             ErrorKind::ConnectionReset => Self::ConnectionReset,
-            ErrorKind::HostUnreachable => Self::HostUnreachable,
-            ErrorKind::NetworkUnreachable => Self::NetworkUnreachable,
             ErrorKind::ConnectionAborted => Self::ConnectionAborted,
             ErrorKind::NotConnected => Self::NotConnected,
             ErrorKind::AddrInUse => Self::AddrInUse,
             ErrorKind::AddrNotAvailable => Self::AddrNotAvailable,
-            ErrorKind::NetworkDown => Self::NetworkDown,
             ErrorKind::BrokenPipe => Self::BrokenPipe,
             ErrorKind::AlreadyExists => Self::AlreadyExists,
             ErrorKind::WouldBlock => Self::WouldBlock,
-            ErrorKind::NotADirectory => Self::NotADirectory,
-            ErrorKind::IsADirectory => Self::IsADirectory,
-            ErrorKind::DirectoryNotEmpty => Self::DirectoryNotEmpty,
-            ErrorKind::ReadOnlyFilesystem => Self::ReadOnlyFilesystem,
-            ErrorKind::FilesystemLoop => Self::FilesystemLoop,
-            ErrorKind::StaleNetworkFileHandle => Self::StaleNetworkFileHandle,
             ErrorKind::InvalidInput => Self::InvalidInput,
             ErrorKind::InvalidData => Self::InvalidData,
             ErrorKind::TimedOut => Self::TimedOut,
             ErrorKind::WriteZero => Self::WriteZero,
-            ErrorKind::StorageFull => Self::StorageFull,
-            ErrorKind::NotSeekable => Self::NotSeekable,
-            ErrorKind::FilesystemQuotaExceeded => Self::FilesystemQuotaExceeded,
-            ErrorKind::FileTooLarge => Self::FileTooLarge,
-            ErrorKind::ResourceBusy => Self::ResourceBusy,
-            ErrorKind::ExecutableFileBusy => Self::ExecutableFileBusy,
-            ErrorKind::Deadlock => Self::Deadlock,
-            ErrorKind::CrossesDevices => Self::CrossesDevices,
-            ErrorKind::TooManyLinks => Self::TooManyLinks,
-            ErrorKind::InvalidFilename => Self::InvalidFilename,
-            ErrorKind::ArgumentListTooLong => Self::ArgumentListTooLong,
             ErrorKind::Interrupted => Self::Interrupted,
             ErrorKind::Unsupported => Self::Unsupported,
             ErrorKind::UnexpectedEof => Self::UnexpectedEof,

--- a/src/ffi/json.rs
+++ b/src/ffi/json.rs
@@ -5,7 +5,11 @@ use std::fmt::{Display, Formatter};
 use crate::ffi::io::error::IoError;
 
 /// Replicates [serde_json::value::Value], but with `uniffi` support.
-#[derive(Clone, Debug, PartialEq, Eq, uniffi::Enum)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Enum)
+)]
 pub enum JSON {
     /// JSON `null`
     Null,
@@ -35,11 +39,9 @@ pub enum JSON {
         object: HashMap<String, JSON>,
     },
 }
-#[uniffi::export]
 impl JSON {
     /// Deserializes JSON serialized to a string to `JSON` or errors with a
     /// [JSONDeserializationError] if the string is invalid JSON.
-    #[uniffi::constructor]
     pub fn deserialize(serialized: String) -> Result<Self, JSONDeserializationError> {
         serde_json::from_str::<serde_json::Value>(serialized.as_str())
             .map(From::from)
@@ -118,7 +120,11 @@ impl From<&serde_json::Value> for JSON {
 }
 
 /// Replicates [serde_json::number::Number] and [serde_json::number::N], but with `uniffi` support.
-#[derive(Copy, Clone, Debug, PartialEq, uniffi::Enum)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Enum)
+)]
 pub enum Number {
     PosInt { pos: u64 },
     NegInt { neg: i64 },
@@ -161,7 +167,11 @@ impl From<&serde_json::Number> for Number {
 }
 
 /// Error from [JSON::deserialize]
-#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[derive(Debug, thiserror::Error)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Error)
+)]
 pub enum JSONDeserializationError {
     /// There was error reading from the underlying IO device after reading `column` of `line`.
     #[error("IO error on line {line} column {column}: {io_error}")]

--- a/src/ffi/message.rs
+++ b/src/ffi/message.rs
@@ -10,7 +10,11 @@ use crate::rust;
 /// We discriminate between special Phoenix events and user-defined events, as they have slightly
 /// different semantics. Generally speaking, Phoenix events are not exposed to users, and are not
 /// permitted to be sent by them either.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, uniffi::Enum)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Enum)
+)]
 pub enum Event {
     /// Represents one of the built-in Phoenix channel events, e.g. join
     Phoenix {
@@ -23,11 +27,9 @@ pub enum Event {
         user: String,
     },
 }
-#[uniffi::export]
 impl Event {
     /// Creates an [Event] from a string and ensures that special Phoenix control events are turned
     /// into [Event::Phoenix] while others are [Event::User].
-    #[uniffi::constructor]
     pub fn from_string(name: String) -> Self {
         let rust_event: rust::message::Event = name.into();
 
@@ -52,7 +54,11 @@ impl From<rust::message::Event> for Event {
 }
 
 /// Represents special events related to management of Phoenix channels.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, uniffi::Enum)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Enum)
+)]
 pub enum PhoenixEvent {
     /// Used when sending a message to join a channel
     Join = 0,
@@ -96,7 +102,11 @@ impl FromStr for PhoenixEvent {
 }
 
 /// Contains the response payload sent to/received from Phoenix
-#[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Enum)
+)]
 pub enum Payload {
     /// A JSON payload
     JSON {
@@ -109,17 +119,14 @@ pub enum Payload {
         bytes: Vec<u8>,
     },
 }
-#[uniffi::export]
 impl Payload {
     /// Deserializes JSON serialized to a string to [Payload::JSON] or errors with a
     /// [JSONDeserializationError] if the string is invalid JSON.
-    #[uniffi::constructor]
     pub fn json_from_serialized(serialized_json: String) -> Result<Self, JSONDeserializationError> {
         JSON::deserialize(serialized_json).map(|json| Self::JSON { json })
     }
 
     /// Stores bytes in [Payload::Binary].
-    #[uniffi::constructor]
     pub fn binary_from_bytes(bytes: Vec<u8>) -> Self {
         Self::Binary { bytes }
     }

--- a/src/ffi/observable_status.rs
+++ b/src/ffi/observable_status.rs
@@ -1,6 +1,10 @@
 /// Wraps [tokio::sync::broadcast::error::RecvError] to add `uniffi` support and names specific to
 /// [Statuses](crate::rust::observable_status::Statuses).
-#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[derive(Debug, thiserror::Error)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Error)
+)]
 pub enum StatusesError {
     #[error("No more statuses left")]
     NoMoreStatuses,

--- a/src/ffi/topic.rs
+++ b/src/ffi/topic.rs
@@ -4,9 +4,14 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 /// A [Channel](crate::Channel) topic.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Object)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Object)
+)]
 pub struct Topic(String);
 
+#[cfg(feature = "uniffi")]
 #[uniffi::export]
 impl Topic {
     /// Create [Topic] from string.
@@ -15,6 +20,14 @@ impl Topic {
         Arc::new(Topic(topic))
     }
 }
+
+#[cfg(not(feature = "uniffi"))]
+impl Topic {
+    pub fn from_string(topic: String) -> Arc<Self> {
+        Arc::new(Topic(topic))
+    }
+}
+
 
 impl Debug for Topic {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/src/ffi/web_socket/error.rs
+++ b/src/ffi/web_socket/error.rs
@@ -5,11 +5,15 @@ use tokio_tungstenite::tungstenite::Error as TungsteniteError;
 
 use crate::ffi::http;
 use crate::ffi::io;
-use crate::ffi::web_socket::protocol::frame::coding::Data;
+use crate::ffi::web_socket::protocol::frame::coding::TungsteniteData;
 use crate::ffi::web_socket::protocol::WebSocketMessage;
 
 /// [tokio_tungstenite::tungstenite::error::Error], but with `uniffi` support
-#[derive(Clone, Debug, thiserror::Error, uniffi::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Error)
+)]
 pub enum WebSocketError {
     /// WebSocket connection closed normally. This informs you of the close.
     /// It's not an error as such and nothing wrong happened.
@@ -130,7 +134,11 @@ impl From<&TungsteniteError> for WebSocketError {
 
 /// [tungstenite::error::CapacityError], but with `uniffi` support.
 /// Indicates the specific type/cause of a capacity error.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, thiserror::Error, uniffi::Error)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, thiserror::Error)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Error)
+)]
 pub enum CapacityError {
     /// Too many headers provided (see [`httparse::Error::TooManyHeaders`]).
     #[error("Too many headers")]
@@ -159,7 +167,11 @@ impl From<&TungsteniteCapacityError> for CapacityError {
 
 /// [tokio_tungstenite::tungstenite::error::ProtocolError], but with `uniffi` support.
 /// Indicates the specific type/cause of a protocol error.
-#[derive(Debug, PartialEq, Eq, Clone, thiserror::Error, uniffi::Error)]
+#[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Error)
+)]
 pub enum ProtocolError {
     /// Use of the wrong HTTP method (the WebSocket protocol requires the GET method be used).
     #[error("Unsupported HTTP method used - only GET is allowed")]
@@ -231,7 +243,7 @@ pub enum ProtocolError {
     UnexpectedContinueFrame,
     /// Received data while waiting for more fragments.
     #[error("While waiting for more fragments received: {data}")]
-    ExpectedFragment { data: Data },
+    ExpectedFragment { data: TungsteniteData },
     /// Connection closed without performing the closing handshake.
     #[error("Connection reset without closing handshake")]
     ResetWithoutClosingHandshake,

--- a/src/ffi/web_socket/protocol.rs
+++ b/src/ffi/web_socket/protocol.rs
@@ -4,7 +4,11 @@ pub(crate) mod frame;
 
 /// [tokio_tungstenite::tungstenite::protocol::Message], but with `uniffi` support.
 /// An enum representing the various forms of a WebSocket message.
-#[derive(Debug, Eq, PartialEq, Clone, uniffi::Enum)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Enum)
+)]
 pub enum WebSocketMessage {
     /// A text WebSocket message
     Text {

--- a/src/ffi/web_socket/protocol/frame.rs
+++ b/src/ffi/web_socket/protocol/frame.rs
@@ -1,10 +1,14 @@
-use coding::{CloseCode, OpCode};
+use coding::{TungsteniteCloseCode, TungsteniteOpCode};
 
 pub(crate) mod coding;
 
 /// [tokio_tungstenite::tungstenite::protocol::frame::Frame], but with `uniffi` support.
 /// A struct representing a WebSocket frame.
-#[derive(Debug, Clone, Eq, PartialEq, uniffi::Record)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Record)
+)]
 pub struct Frame {
     header: FrameHeader,
     payload: Vec<u8>,
@@ -21,7 +25,11 @@ impl From<&tokio_tungstenite::tungstenite::protocol::frame::Frame> for Frame {
 /// [tokio_tungstenite::tungstenite::protocol::frame::FrameHeader], but with `uniffi` support.
 /// A struct representing a WebSocket frame header.
 #[allow(missing_copy_implementations)]
-#[derive(Debug, Clone, Eq, PartialEq, uniffi::Record)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Record)
+)]
 pub struct FrameHeader {
     /// Indicates that the frame is the last one of a possibly fragmented message.
     pub is_final: bool,
@@ -32,7 +40,7 @@ pub struct FrameHeader {
     /// Reserved for protocol extensions.
     pub rsv3: bool,
     /// WebSocket protocol opcode.
-    pub opcode: OpCode,
+    pub opcode: TungsteniteOpCode,
     /// A frame mask, if any.
     pub mask: Option<Vec<u8>>,
 }
@@ -62,10 +70,14 @@ impl From<&tokio_tungstenite::tungstenite::protocol::frame::FrameHeader> for Fra
 
 /// [tokio_tungstenite::tungstenite::protocol::frame::CloseFrame], but with `uniffi::support`
 /// A struct representing the close command.
-#[derive(Debug, Clone, Eq, PartialEq, uniffi::Record)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Record)
+)]
 pub struct CloseFrame {
     /// The reason as a code.
-    pub code: CloseCode,
+    pub code: TungsteniteCloseCode,
     /// The reason as text string.
     pub reason: String,
 }

--- a/src/ffi/web_socket/protocol/frame/coding.rs
+++ b/src/ffi/web_socket/protocol/frame/coding.rs
@@ -1,25 +1,26 @@
 use std::fmt;
 use std::fmt::Display;
 
-use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode as TungsteniteCloseCode;
-use tokio_tungstenite::tungstenite::protocol::frame::coding::Control as TungsteniteControl;
-use tokio_tungstenite::tungstenite::protocol::frame::coding::Data as TungsteniteData;
-use tokio_tungstenite::tungstenite::protocol::frame::coding::OpCode as TungsteniteOpCode;
+use tokio_tungstenite::tungstenite::protocol::frame::coding as tungstenite_coding;
 
 /// [tokio_tungstenite::tungstenite::protocol::frame::coding::OpCode], but with `uniffi` support
 /// WebSocket message opcode as in RFC 6455.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, uniffi::Enum)]
-pub enum OpCode {
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Enum)
+)]
+pub enum TungsteniteOpCode {
     /// Data (text or binary).
-    Data { data: Data },
+    Data { data: TungsteniteData },
     /// Control message (close, ping, pong).
-    Control { control: Control },
+    Control { control: TungsteniteControl },
 }
-impl From<&TungsteniteOpCode> for OpCode {
-    fn from(rust_opcode: &TungsteniteOpCode) -> Self {
+impl From<&tungstenite_coding::OpCode> for TungsteniteOpCode {
+    fn from(rust_opcode: &tungstenite_coding::OpCode) -> Self {
         match rust_opcode {
-            TungsteniteOpCode::Data(data) => Self::Data { data: data.into() },
-            TungsteniteOpCode::Control(control) => Self::Control {
+            tungstenite_coding::OpCode::Data(data) => Self::Data { data: data.into() },
+            tungstenite_coding::OpCode::Control(control) => Self::Control {
                 control: control.into(),
             },
         }
@@ -28,8 +29,12 @@ impl From<&TungsteniteOpCode> for OpCode {
 
 /// [tokio_tungstenite::tungstenite::protocol::frame::coding::Data], but with `uniffi` support.
 /// Data opcodes as in RFC 6455
-#[derive(Debug, PartialEq, Eq, Clone, Copy, uniffi::Enum)]
-pub enum Data {
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Enum)
+)]
+pub enum TungsteniteData {
     /// 0x0 denotes a continuation frame
     Continue,
     /// 0x1 denotes a text frame
@@ -39,31 +44,35 @@ pub enum Data {
     /// 0x3-7 are reserved for further non-control frames
     Reserved { bits: u8 },
 }
-impl Display for Data {
+impl Display for TungsteniteData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Data::Continue => write!(f, "CONTINUE"),
-            Data::Text => write!(f, "TEXT"),
-            Data::Binary => write!(f, "BINARY"),
-            Data::Reserved { bits } => write!(f, "RESERVED_DATA_{}", bits),
+            TungsteniteData::Continue => write!(f, "CONTINUE"),
+            TungsteniteData::Text => write!(f, "TEXT"),
+            TungsteniteData::Binary => write!(f, "BINARY"),
+            TungsteniteData::Reserved { bits } => write!(f, "RESERVED_DATA_{}", bits),
         }
     }
 }
-impl From<&TungsteniteData> for Data {
-    fn from(rust_data: &TungsteniteData) -> Self {
+impl From<&tungstenite_coding::Data> for TungsteniteData {
+    fn from(rust_data: &tungstenite_coding::Data) -> Self {
         match rust_data {
-            TungsteniteData::Continue => Self::Continue,
-            TungsteniteData::Text => Self::Text,
-            TungsteniteData::Binary => Self::Binary,
-            TungsteniteData::Reserved(bits) => Self::Reserved { bits: *bits },
+            tungstenite_coding::Data::Continue => Self::Continue,
+            tungstenite_coding::Data::Text => Self::Text,
+            tungstenite_coding::Data::Binary => Self::Binary,
+            tungstenite_coding::Data::Reserved(bits) => Self::Reserved { bits: *bits },
         }
     }
 }
 
 /// [tokio_tungstenite::tungstenite::protocol::frame::coding::Control], but with `uniffi` support.
 /// Control opcodes as in RFC 6455
-#[derive(Debug, PartialEq, Eq, Clone, Copy, uniffi::Enum)]
-pub enum Control {
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Enum)
+)]
+pub enum TungsteniteControl {
     /// 0x8 denotes a connection close
     Close,
     /// 0x9 denotes a ping
@@ -73,21 +82,25 @@ pub enum Control {
     /// 0xb-f are reserved for further control frames
     Reserved { bit: u8 },
 }
-impl From<&TungsteniteControl> for Control {
-    fn from(rust_control: &TungsteniteControl) -> Self {
+impl From<&tungstenite_coding::Control> for TungsteniteControl {
+    fn from(rust_control: &tungstenite_coding::Control) -> Self {
         match rust_control {
-            TungsteniteControl::Close => Self::Close,
-            TungsteniteControl::Ping => Self::Ping,
-            TungsteniteControl::Pong => Self::Pong,
-            TungsteniteControl::Reserved(bit) => Self::Reserved { bit: *bit },
+            tungstenite_coding::Control::Close => Self::Close,
+            tungstenite_coding::Control::Ping => Self::Ping,
+            tungstenite_coding::Control::Pong => Self::Pong,
+            tungstenite_coding::Control::Reserved(bit) => Self::Reserved { bit: *bit },
         }
     }
 }
 
 /// [tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode], but with `uniffi::support`
 /// Status code used to indicate why an endpoint is closing the WebSocket connection.
-#[derive(Debug, Eq, PartialEq, Clone, Copy, uniffi::Enum)]
-pub enum CloseCode {
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(
+    feature = "uniffi",
+    derive(uniffi::Enum)
+)]
+pub enum TungsteniteCloseCode {
     /// Indicates a normal closure, meaning that the purpose for
     /// which the connection was established has been fulfilled.
     Normal,
@@ -146,38 +159,33 @@ pub enum CloseCode {
     /// to a different IP (when multiple targets exist), or reconnect to the same IP
     /// when a user has performed an action.
     Again,
-    #[doc(hidden)]
     Tls,
-    #[doc(hidden)]
     Reserved { code: u16 },
-    #[doc(hidden)]
     Iana { code: u16 },
-    #[doc(hidden)]
     Library { code: u16 },
-    #[doc(hidden)]
     Bad { code: u16 },
 }
-impl From<&TungsteniteCloseCode> for CloseCode {
-    fn from(rust_close_code: &TungsteniteCloseCode) -> Self {
+impl From<&tungstenite_coding::CloseCode> for TungsteniteCloseCode {
+    fn from(rust_close_code: &tungstenite_coding::CloseCode) -> Self {
         match rust_close_code {
-            TungsteniteCloseCode::Normal => Self::Normal,
-            TungsteniteCloseCode::Away => Self::Away,
-            TungsteniteCloseCode::Protocol => Self::Protocol,
-            TungsteniteCloseCode::Unsupported => Self::Unsupported,
-            TungsteniteCloseCode::Status => Self::Status,
-            TungsteniteCloseCode::Abnormal => Self::Abnormal,
-            TungsteniteCloseCode::Invalid => Self::Invalid,
-            TungsteniteCloseCode::Policy => Self::Policy,
-            TungsteniteCloseCode::Size => Self::Size,
-            TungsteniteCloseCode::Extension => Self::Extension,
-            TungsteniteCloseCode::Error => Self::Error,
-            TungsteniteCloseCode::Restart => Self::Restart,
-            TungsteniteCloseCode::Again => Self::Again,
-            TungsteniteCloseCode::Tls => Self::Tls,
-            TungsteniteCloseCode::Reserved(code) => Self::Reserved { code: *code },
-            TungsteniteCloseCode::Iana(code) => Self::Iana { code: *code },
-            TungsteniteCloseCode::Library(code) => Self::Library { code: *code },
-            TungsteniteCloseCode::Bad(code) => Self::Bad { code: *code },
+            tungstenite_coding::CloseCode::Normal => Self::Normal,
+            tungstenite_coding::CloseCode::Away => Self::Away,
+            tungstenite_coding::CloseCode::Protocol => Self::Protocol,
+            tungstenite_coding::CloseCode::Unsupported => Self::Unsupported,
+            tungstenite_coding::CloseCode::Status => Self::Status,
+            tungstenite_coding::CloseCode::Abnormal => Self::Abnormal,
+            tungstenite_coding::CloseCode::Invalid => Self::Invalid,
+            tungstenite_coding::CloseCode::Policy => Self::Policy,
+            tungstenite_coding::CloseCode::Size => Self::Size,
+            tungstenite_coding::CloseCode::Extension => Self::Extension,
+            tungstenite_coding::CloseCode::Error => Self::Error,
+            tungstenite_coding::CloseCode::Restart => Self::Restart,
+            tungstenite_coding::CloseCode::Again => Self::Again,
+            tungstenite_coding::CloseCode::Tls => Self::Tls,
+            tungstenite_coding::CloseCode::Reserved(code) => Self::Reserved { code: *code },
+            tungstenite_coding::CloseCode::Iana(code) => Self::Iana { code: *code },
+            tungstenite_coding::CloseCode::Library(code) => Self::Library { code: *code },
+            tungstenite_coding::CloseCode::Bad(code) => Self::Bad { code: *code },
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(feature = "nightly", feature(slice_take))]
-#![feature(async_closure)]
-#![feature(io_error_more)]
-#![feature(io_error_uncategorized)]
 // doc warnings that aren't on by default
 #![warn(missing_docs)]
 #![warn(rustdoc::unescaped_backticks)]
@@ -18,10 +15,11 @@ pub use ffi::channel::{
 pub use ffi::io::error::IoError;
 pub use ffi::json::{JSONDeserializationError, JSON};
 pub use ffi::message::{Event, Payload, PhoenixEvent};
-pub use ffi::socket::{ConnectError, Socket, SocketStatus};
+pub use ffi::socket::{ConnectError, Socket, SocketStatus, SocketStatuses, SocketError};
 pub use ffi::topic::Topic;
 pub use ffi::web_socket::error::WebSocketError;
 pub use ffi::web_socket::protocol::WebSocketMessage;
-pub use ffi::Error;
+pub use ffi::PhoenixError;
 
-uniffi::include_scaffolding!("phoenix_channels_client");
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!("phoenix_channels_client");

--- a/src/phoenix_channels_client.udl
+++ b/src/phoenix_channels_client.udl
@@ -1,2 +1,0 @@
-namespace phoenix_channels_client {
-};

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 // the foreign bindings
 use phoenix_channels_client::{
     CallError, ChannelJoinError, ChannelStatus, ChannelStatusJoinError, ChannelStatuses,
-    ConnectError, Error, Event, EventPayload, IoError, Payload, Socket, SocketStatus, Topic,
+    ConnectError, PhoenixError, Event, EventPayload, IoError, Payload, Socket, SocketStatus, Topic,
     WebSocketError, JSON,
 };
 
@@ -36,7 +36,7 @@ macro_rules! assert_matches {
 }
 
 #[tokio::test]
-async fn socket_status() -> Result<(), Error> {
+async fn socket_status() -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -66,7 +66,7 @@ async fn socket_status() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn socket_statuses() -> Result<(), Error> {
+async fn socket_statuses() -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -147,7 +147,7 @@ async fn socket_statuses() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn channel_status() -> Result<(), Error> {
+async fn channel_status() -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -185,7 +185,7 @@ async fn channel_status() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn channel_statuses() -> Result<(), Error> {
+async fn channel_statuses() -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -303,7 +303,7 @@ async fn channel_statuses() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn channel_key_rotation_test() -> Result<(), Error> {
+async fn channel_key_rotation_test() -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -364,7 +364,7 @@ async fn channel_key_rotation_test() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn socket_key_rotation_test() -> Result<(), Error> {
+async fn socket_key_rotation_test() -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -432,16 +432,16 @@ async fn socket_key_rotation_test() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn phoenix_channels_socket_disconnect_reconnect_test() -> Result<(), Error> {
+async fn phoenix_channels_socket_disconnect_reconnect_test() -> Result<(), PhoenixError> {
     phoenix_channels_reconnect_test(Event::from_string("socket_disconnect".to_string())).await
 }
 
 #[tokio::test]
-async fn phoenix_channels_transport_error_reconnect_test() -> Result<(), Error> {
+async fn phoenix_channels_transport_error_reconnect_test() -> Result<(), PhoenixError> {
     phoenix_channels_reconnect_test(Event::from_string("transport_error".to_string())).await
 }
 
-async fn phoenix_channels_reconnect_test(event: Event) -> Result<(), Error> {
+async fn phoenix_channels_reconnect_test(event: Event) -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -504,16 +504,16 @@ async fn phoenix_channels_reconnect_test(event: Event) -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn phoenix_channels_join_json_payload_test() -> Result<(), Error> {
+async fn phoenix_channels_join_json_payload_test() -> Result<(), PhoenixError> {
     phoenix_channels_join_payload_test("json", json_payload()).await
 }
 
 #[tokio::test]
-async fn phoenix_channels_join_binary_payload_test() -> Result<(), Error> {
+async fn phoenix_channels_join_binary_payload_test() -> Result<(), PhoenixError> {
     phoenix_channels_join_payload_test("binary", binary_payload()).await
 }
 
-async fn phoenix_channels_join_payload_test(subtopic: &str, payload: Payload) -> Result<(), Error> {
+async fn phoenix_channels_join_payload_test(subtopic: &str, payload: Payload) -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -542,16 +542,16 @@ async fn phoenix_channels_join_payload_test(subtopic: &str, payload: Payload) ->
 }
 
 #[tokio::test]
-async fn phoenix_channels_join_json_error_test() -> Result<(), Error> {
+async fn phoenix_channels_join_json_error_test() -> Result<(), PhoenixError> {
     phoenix_channels_join_error_test("json", json_payload()).await
 }
 
 #[tokio::test]
-async fn phoenix_channels_join_binary_error_test() -> Result<(), Error> {
+async fn phoenix_channels_join_binary_error_test() -> Result<(), PhoenixError> {
     phoenix_channels_join_error_test("binary", binary_payload()).await
 }
 
-async fn phoenix_channels_join_error_test(subtopic: &str, payload: Payload) -> Result<(), Error> {
+async fn phoenix_channels_join_error_test(subtopic: &str, payload: Payload) -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -579,16 +579,16 @@ async fn phoenix_channels_join_error_test(subtopic: &str, payload: Payload) -> R
 }
 
 #[tokio::test]
-async fn phoenix_channels_json_broadcast_test() -> Result<(), Error> {
+async fn phoenix_channels_json_broadcast_test() -> Result<(), PhoenixError> {
     phoenix_channels_broadcast_test("json", json_payload()).await
 }
 
 #[tokio::test]
-async fn phoenix_channels_binary_broadcast_test() -> Result<(), Error> {
+async fn phoenix_channels_binary_broadcast_test() -> Result<(), PhoenixError> {
     phoenix_channels_broadcast_test("binary", binary_payload()).await
 }
 
-async fn phoenix_channels_broadcast_test(subtopic: &str, payload: Payload) -> Result<(), Error> {
+async fn phoenix_channels_broadcast_test(subtopic: &str, payload: Payload) -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -645,21 +645,21 @@ async fn phoenix_channels_broadcast_test(subtopic: &str, payload: Payload) -> Re
 }
 
 #[tokio::test]
-async fn phoenix_channels_call_with_json_payload_reply_ok_without_payload_test() -> Result<(), Error>
+async fn phoenix_channels_call_with_json_payload_reply_ok_without_payload_test() -> Result<(), PhoenixError>
 {
     phoenix_channels_call_reply_ok_without_payload_test("json", json_payload()).await
 }
 
 #[tokio::test]
 async fn phoenix_channels_call_with_binary_payload_reply_ok_without_payload_test(
-) -> Result<(), Error> {
+) -> Result<(), PhoenixError> {
     phoenix_channels_call_reply_ok_without_payload_test("binary", binary_payload()).await
 }
 
 async fn phoenix_channels_call_reply_ok_without_payload_test(
     subtopic: &str,
     payload: Payload,
-) -> Result<(), Error> {
+) -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -691,20 +691,20 @@ async fn phoenix_channels_call_reply_ok_without_payload_test(
 
 #[tokio::test]
 async fn phoenix_channels_call_with_json_payload_reply_error_without_payload_test(
-) -> Result<(), Error> {
+) -> Result<(), PhoenixError> {
     phoenix_channels_call_reply_error_without_payload_test("json", json_payload()).await
 }
 
 #[tokio::test]
 async fn phoenix_channels_call_with_binary_payload_reply_error_without_payload_test(
-) -> Result<(), Error> {
+) -> Result<(), PhoenixError> {
     phoenix_channels_call_reply_error_without_payload_test("binary", binary_payload()).await
 }
 
 async fn phoenix_channels_call_reply_error_without_payload_test(
     subtopic: &str,
     payload: Payload,
-) -> Result<(), Error> {
+) -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -739,19 +739,19 @@ async fn phoenix_channels_call_reply_error_without_payload_test(
 }
 
 #[tokio::test]
-async fn phoenix_channels_call_reply_ok_with_json_payload_test() -> Result<(), Error> {
+async fn phoenix_channels_call_reply_ok_with_json_payload_test() -> Result<(), PhoenixError> {
     phoenix_channels_call_reply_ok_with_payload_test("json", json_payload()).await
 }
 
 #[tokio::test]
-async fn phoenix_channels_call_reply_ok_with_binary_payload_test() -> Result<(), Error> {
+async fn phoenix_channels_call_reply_ok_with_binary_payload_test() -> Result<(), PhoenixError> {
     phoenix_channels_call_reply_ok_with_payload_test("binary", binary_payload()).await
 }
 
 async fn phoenix_channels_call_reply_ok_with_payload_test(
     subtopic: &str,
     payload: Payload,
-) -> Result<(), Error> {
+) -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -787,13 +787,13 @@ async fn phoenix_channels_call_reply_ok_with_payload_test(
 
 #[tokio::test]
 async fn phoenix_channels_call_with_json_payload_reply_error_with_json_payload_test(
-) -> Result<(), Error> {
+) -> Result<(), PhoenixError> {
     phoenix_channels_call_with_payload_reply_error_with_payload_test("json", json_payload()).await
 }
 
 #[tokio::test]
 async fn phoenix_channels_call_with_binary_payload_reply_error_with_binary_payload_test(
-) -> Result<(), Error> {
+) -> Result<(), PhoenixError> {
     phoenix_channels_call_with_payload_reply_error_with_payload_test("binary", binary_payload())
         .await
 }
@@ -801,7 +801,7 @@ async fn phoenix_channels_call_with_binary_payload_reply_error_with_binary_paylo
 async fn phoenix_channels_call_with_payload_reply_error_with_payload_test(
     subtopic: &str,
     payload: Payload,
-) -> Result<(), Error> {
+) -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -836,16 +836,16 @@ async fn phoenix_channels_call_with_payload_reply_error_with_payload_test(
 }
 
 #[tokio::test]
-async fn phoenix_channels_call_with_json_payload_raise_test() -> Result<(), Error> {
+async fn phoenix_channels_call_with_json_payload_raise_test() -> Result<(), PhoenixError> {
     phoenix_channels_call_raise_test("json", json_payload()).await
 }
 
 #[tokio::test]
-async fn phoenix_channels_call_with_binary_payload_raise_test() -> Result<(), Error> {
+async fn phoenix_channels_call_with_binary_payload_raise_test() -> Result<(), PhoenixError> {
     phoenix_channels_call_raise_test("binary", binary_payload()).await
 }
 
-async fn phoenix_channels_call_raise_test(subtopic: &str, payload: Payload) -> Result<(), Error> {
+async fn phoenix_channels_call_raise_test(subtopic: &str, payload: Payload) -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -876,16 +876,16 @@ async fn phoenix_channels_call_raise_test(subtopic: &str, payload: Payload) -> R
 }
 
 #[tokio::test]
-async fn phoenix_channels_cast_error_json_test() -> Result<(), Error> {
+async fn phoenix_channels_cast_error_json_test() -> Result<(), PhoenixError> {
     phoenix_channels_cast_error_test("json", json_payload()).await
 }
 
 #[tokio::test]
-async fn phoenix_channels_cast_error_binary_test() -> Result<(), Error> {
+async fn phoenix_channels_cast_error_binary_test() -> Result<(), PhoenixError> {
     phoenix_channels_cast_error_test("binary", binary_payload()).await
 }
 
-async fn phoenix_channels_cast_error_test(subtopic: &str, payload: Payload) -> Result<(), Error> {
+async fn phoenix_channels_cast_error_test(subtopic: &str, payload: Payload) -> Result<(), PhoenixError> {
     let _ = env_logger::builder()
         .parse_default_env()
         .filter_level(log::LevelFilter::Debug)
@@ -1026,7 +1026,7 @@ async fn assert_joined(channel_statuses: &ChannelStatuses) {
     }
 }
 
-async fn connected_socket(url: Url) -> Result<Arc<Socket>, Error> {
+async fn connected_socket(url: Url) -> Result<Arc<Socket>, PhoenixError> {
     let socket = Socket::spawn(url)?;
 
     if let Err(connect_error) = socket.connect(CONNECT_TIMEOUT).await {
@@ -1056,7 +1056,7 @@ fn shared_secret_url(id: String) -> Url {
     .unwrap()
 }
 
-async fn generate_secret(socket: &Arc<Socket>) -> Result<String, Error> {
+async fn generate_secret(socket: &Arc<Socket>) -> Result<String, PhoenixError> {
     let channel = socket
         .channel(
             Topic::from_string("channel:generate_secret".to_string()),

--- a/uniffi-bindgen.rs
+++ b/uniffi-bindgen.rs
@@ -1,3 +1,7 @@
 fn main() {
+    #[cfg(not(feature = "uniffi"))]
+    panic!("uniffi feature required for uniffi-bindgen");
+    #[cfg(feature = "uniffi")]
     uniffi::uniffi_bindgen_main()
+
 }


### PR DESCRIPTION
These are some changes needed for https://github.com/liveview-native/liveview-native-core/issues/16.

Summary of changes:
* `phoenix_channels_client::Error` renamed to `phoenix_channels_client::PhoenixError` because `Error` is a reserved keyboard in the swift bindings.
* `Opcode`, `Data`, `Control` and `CloseCode` prefixed with `Tungstenite` because `Data` is reserved in the uniffi swift bindings.
* Made uniffi an optional dependency/feature flag because in https://github.com/liveview-native/liveview-native-core/pull/61 this produces two swift packages but it is not easy to join them. This should alleviate those issues.
* Added a `uniffi-check`CI job because the proc-macros can produce a library which uniffi-bindgen fails to generate swift/kotlin bindings from.
* Removed some nightly feature dependencies.