### PR TITLE
More updates for file upload and fixing uniffi docstrings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,9 +608,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+checksum = "bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887"
 dependencies = [
  "log",
  "plain",
@@ -1129,18 +1129,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1252,6 +1252,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1323,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1485,6 +1502,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,10 +1517,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi"
-version = "0.25.3"
+name = "unicode-width"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21345172d31092fd48c47fd56c53d4ae9e41c4b1f559fb8c38c1ab1685fd919f"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "uniffi"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad0be8bba6c242d2d16922de4a9c8f167b9491729fda552e70f8626bf7302cb"
 dependencies = [
  "anyhow",
  "camino",
@@ -1510,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd992f2929a053829d5875af1eff2ee3d7a7001cb3b9a46cc7895f2caede6940"
+checksum = "ab31006ab9c9c6870739f0e74235729d1478d82e73571b8f53c25aa176d67535"
 dependencies = [
  "anyhow",
  "askama",
@@ -1526,6 +1555,7 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
+ "textwrap",
  "toml",
  "uniffi_meta",
  "uniffi_testing",
@@ -1534,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001964dd3682d600084b3aaf75acf9c3426699bc27b65e96bb32d175a31c74e9"
+checksum = "4aa3a7608c6872dc1ce53199d816a24d2e19af952d82ce557ecc8692a4ae9cba"
 dependencies = [
  "anyhow",
  "camino",
@@ -1545,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55137c122f712d9330fd985d66fa61bdc381752e89c35708c13ce63049a3002c"
+checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
 dependencies = [
  "quote",
  "syn",
@@ -1555,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6121a127a3af1665cd90d12dd2b3683c2643c5103281d0fed5838324ca1fad5b"
+checksum = "8d6e8db3f4e558faf0e25ac4b5bd775567973a4e18809f1123e74de52a853692"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1572,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cf7a58f101fcedafa5b77ea037999b88748607f0ef3a33eaa0efc5392e92e4"
+checksum = "a126650799f97d97d8e38e3f10f15c65f5bc5a76b021bec21823efe9dd831a02"
 dependencies = [
  "bincode",
  "camino",
@@ -1591,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dc8573a7b1ac4b71643d6da34888273ebfc03440c525121f1b3634ad3417a2"
+checksum = "3f64a99e905671738d9d293f9cce58708ce1af8e13ea29f9d6b6925114fc2e85"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1603,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118448debffcb676ddbe8c5305fb933ab7e0123753e659a71dc4a693f8d9f23c"
+checksum = "cdca5719a22edf34c8239cc6ac9e3906d7ebc2a3e8a5e6ece4c3dffc312a4251"
 dependencies = [
  "anyhow",
  "camino",
@@ -1616,11 +1646,12 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889edb7109c6078abe0e53e9b4070cf74a6b3468d141bdf5ef1bd4d1dc24a1c3"
+checksum = "3f6817c15714acccd0d0459f99b524cabebfdd622376464a2c6466a6485bdb4b"
 dependencies = [
  "anyhow",
+ "textwrap",
  "uniffi_meta",
  "uniffi_testing",
  "weedle2",
@@ -1732,9 +1763,9 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "weedle2"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,15 +48,15 @@ strum_macros = "0.25.0"
 thiserror = "1.0"
 tokio = { version = "1.35", features = ["sync", "macros", "time", "tracing"] }
 tokio-tungstenite = "0.21.0"
-uniffi = { version = "0.25.3", features = ["cli", "tokio"] }
+uniffi = { version = "0.26", features = ["cli", "tokio"] }
 url = "2.5"
 uuid = { version = "1.7.0", features = ["v4"] }
 
 [dev-dependencies]
 chrono = "0.4.31"
 env_logger = "0.10"
-uniffi = { version = "0.25.3", features = ["bindgen-tests", "tokio", "cli"]}
+uniffi = { version = "0.26", features = ["bindgen-tests", "tokio", "cli"]}
 tokio = { version = "1.35", features = ["full", "tracing", "test-util"] }
 
 [build-dependencies]
-uniffi = { version = "0.25.3", features = ["build"] }
+uniffi = { version = "0.26", features = ["build"] }

--- a/src/ffi/channel.rs
+++ b/src/ffi/channel.rs
@@ -715,38 +715,57 @@ impl From<rust::channel::CallError> for CallError {
     }
 }
 
+/// Errors for when leaving a channel fails.
 #[derive(Clone, Debug, thiserror::Error, uniffi::Error)]
 pub enum LeaveError {
-    #[error("timeout joining channel")]
+    /// The leave operation timeout.
+    #[error("timeout leaving channel")]
     Timeout,
+    /// The channel was shutting down when the client was leaving the channel.
     #[error("channel shutting down")]
     ShuttingDown,
+    /// The channel was shutting down when the client was leaving the channel.
     #[error("channel already shutdown")]
     Shutdown,
+    /// The channel already shut down when the client was leaving the channel.
     #[error("socket shutdown: {socket_shutdown_error}")]
     SocketShutdown {
+        /// The shut down error
         socket_shutdown_error: SocketShutdownError,
     },
+    /// There was a websocket error when the client was leaving the channel.
     #[error("web socket error {web_socket_error:?}")]
     WebSocket {
+        /// The specific websocket error for this shutdown.
         web_socket_error: web_socket::error::WebSocketError,
     },
+    /// The server rejected the clients request to leave the channel.
     #[error("server rejected leave")]
     Rejected {
         /// Response from the server of why the leave was rejected
         rejection: Payload,
     },
+    /// A join was initiated before the server could respond if leave was successful
     #[error("A join was initiated before the server could respond if leave was successful")]
     JoinBeforeLeft,
+    /// There was a URL error when leaving the channel.
     #[error("URL error: {url_error}")]
-    Url { url_error: String },
+    Url {
+        /// The url error itself.
+        url_error: String
+    },
+    /// There was an HTTP error when leaving the cheannel.
     #[error("HTTP error: {}", response.status_code)]
     Http {
+        /// The http response for the error.
         response: crate::ffi::http::Response,
     },
     /// HTTP format error.
     #[error("HTTP format error: {error}")]
-    HttpFormat { error: crate::ffi::http::HttpError },
+    HttpFormat {
+        /// The http error.
+        error: crate::ffi::http::HttpError
+    },
 }
 impl From<ChannelShutdownError> for LeaveError {
     fn from(shutdown_error: ChannelShutdownError) -> Self {

--- a/src/ffi/io/error.rs
+++ b/src/ffi/io/error.rs
@@ -3,32 +3,31 @@ use std::io::ErrorKind;
 /// [std::io::Error] and [std::io::ErrorKind], but with `uniffi` support.
 #[derive(Clone, Debug, thiserror::Error, uniffi::Error)]
 pub enum IoError {
-    /// An entity was not found, often a file.
+    /// An entity was not found.
     #[error("entity not found")]
     NotFound,
-    /// The operation lacked the necessary privileges to complete.
+    /// Permission Denied for this operation.
     #[error("permission defined")]
     PermissionDenied,
-    /// The connection was refused by the remote server.
+    /// The connection was refused.
     #[error("connection refused")]
     ConnectionRefused,
-    /// The connection was reset by the remote server.
+    /// The connection was reset by server.
     #[error("connection reset")]
     ConnectionReset,
-    /// The remote host is not reachable.
+    /// The host is not reachable.
     #[error("host unreachable")]
     HostUnreachable,
-    /// The network containing the remote host is not reachable.
+    /// The network for the host is not reachable.
     #[error("network unreachable")]
     NetworkUnreachable,
-    /// The connection was aborted (terminated) by the remote server.
+    /// The connection was aborted by the remote server.
     #[error("connection aborted")]
     ConnectionAborted,
-    /// The network operation failed because it was not connected yet.
+    /// The network operation failed because it is not connected yet.
     #[error("not connected")]
     NotConnected,
-    /// A socket address could not be bound because the address is already in
-    /// use elsewhere.
+    /// A socket address is already in use elsewhere.
     #[error("address in use")]
     AddrInUse,
     /// A nonexistent interface was requested or the requested address was not
@@ -41,7 +40,7 @@ pub enum IoError {
     /// The operation failed because a pipe was closed.
     #[error("broken pipe")]
     BrokenPipe,
-    /// An entity already exists, often a file.
+    /// An entity already exists.
     #[error("entity already exists")]
     AlreadyExists,
     /// The operation needs to block to complete, but the blocking operation was
@@ -49,35 +48,30 @@ pub enum IoError {
     #[error("operation would block")]
     WouldBlock,
     /// A filesystem object is, unexpectedly, not a directory.
-    ///
-    /// For example, a filesystem path was specified where one of the intermediate directory
-    /// components was, in fact, a plain file.
     #[error("not a directory")]
     NotADirectory,
     /// The filesystem object is, unexpectedly, a directory.
-    ///
-    /// A directory was specified when a non-directory was expected.
     #[error("is a directory")]
     IsADirectory,
-    /// A non-empty directory was specified where an empty directory was expected.
+    /// A non-empty directory was specified when a empty directory was expected.
     #[error("directory not empty")]
     DirectoryNotEmpty,
-    /// The filesystem or storage medium is read-only, but a write operation was attempted.
+    /// The filesystem is read-only when a write operation was attempted.
     #[error("read-only filesystem or storage medium")]
     ReadOnlyFilesystem,
     /// Loop in the filesystem or IO subsystem; often, too many levels of symbolic links.
     ///
     /// There was a loop (or excessively long chain) resolving a filesystem object
     /// or file IO object.
-    ///
-    /// On Unix this is usually the result of a symbolic link loop; or, of exceeding the
-    /// system-specific limit on the depth of symlink traversal.
+    //
+    // On Unix this is usually the result of a symbolic link loop; or, of exceeding the
+    // system-specific limit on the depth of symlink traversal.
     #[error("filesystem loop or indirection limit (e.g. symlink loop)")]
     FilesystemLoop,
     /// Stale network file handle.
-    ///
-    /// With some network filesystems, notably NFS, an open file (or directory) can be invalidated
-    /// by problems with the network or server.
+    //
+    // With some network filesystems, notably NFS, an open file (or directory) can be invalidated
+    // by problems with the network or server.
     #[error("stale network file handle")]
     StaleNetworkFileHandle,
     /// A parameter was incorrect.
@@ -85,64 +79,64 @@ pub enum IoError {
     InvalidInput,
     /// Data not valid for the operation were encountered.
     ///
-    /// Unlike [`InvalidInput`], this typically means that the operation
-    /// parameters were valid, however the error was caused by malformed
-    /// input data.
-    ///
-    /// For example, a function that reads a file into a string will error with
-    /// `InvalidData` if the file's contents are not valid UTF-8.
-    ///
-    /// [`InvalidInput`]: ErrorKind::InvalidInput
+    // Unlike [`InvalidInput`], this typically means that the operation
+    // parameters were valid, however the error was caused by malformed
+    // input data.
+    //
+    // For example, a function that reads a file into a string will error with
+    // `InvalidData` if the file's contents are not valid UTF-8.
+    //
+    // [`InvalidInput`]: ErrorKind::InvalidInput
     #[error("invalid data")]
     InvalidData,
-    /// The I/O operation's timeout expired, causing it to be canceled.
+    /// The I/O operation's timeout expired.
     #[error("timed out")]
     TimedOut,
     /// An error returned when an operation could not be completed because a
     /// call to [`write`] returned [`Ok(0)`].
     ///
-    /// This typically means that an operation could only succeed if it wrote a
-    /// particular number of bytes but only a smaller number of bytes could be
-    /// written.
-    ///
-    /// [`write`]: std::io::Write::write
-    /// [`Ok(0)`]: Ok
+    // This typically means that an operation could only succeed if it wrote a
+    // particular number of bytes but only a smaller number of bytes could be
+    // written.
+    //
+    // [`write`]: std::io::Write::write
+    // [`Ok(0)`]: Ok
     #[error("write zero")]
     WriteZero,
-    /// The underlying storage (typically, a filesystem) is full.
-    ///
-    /// This does not include out of quota errors.
+    /// The underlying storage is full.
+    //
+    // This does not include out of quota errors.
     #[error("no storage space")]
     StorageFull,
     /// Seek on unseekable file.
-    ///
-    /// Seeking was attempted on an open file handle which is not suitable for seeking - for
-    /// example, on Unix, a named pipe opened with `File::open`.
+    //
+    // Seeking was attempted on an open file handle which is not suitable for seeking - for
+    // example, on Unix, a named pipe opened with `File::open`.
     #[error("seek on unseekable file")]
     NotSeekable,
     /// Filesystem quota was exceeded.
     #[error("filesystem quota exceeded")]
     FilesystemQuotaExceeded,
     /// File larger than allowed or supported.
-    ///
-    /// This might arise from a hard limit of the underlying filesystem or file access API, or from
-    /// an administratively imposed resource limitation.  Simple disk full, and out of quota, have
-    /// their own errors.
+    //
+    // This might arise from a hard limit of the underlying filesystem or file access API, or from
+    // an administratively imposed resource limitation.  Simple disk full, and out of quota, have
+    // their own errors.
     #[error("file too large")]
     FileTooLarge,
     /// Resource is busy.
     #[error("resource busy")]
     ResourceBusy,
     /// Executable file is busy.
-    ///
-    /// An attempt was made to write to a file which is also in use as a running program.  (Not all
-    /// operating systems detect this situation.)
+    //
+    // An attempt was made to write to a file which is also in use as a running program.  (Not all
+    // operating systems detect this situation.)
     #[error("executable file busy")]
     ExecutableFileBusy,
     /// Deadlock (avoided).
-    ///
-    /// A file locking operation would result in deadlock.  This situation is typically detected, if
-    /// at all, on a best-effort basis.
+    //
+    // A file locking operation would result in deadlock.  This situation is typically detected, if
+    // at all, on a best-effort basis.
     #[error("deadlock")]
     Deadlock,
     /// Cross-device or cross-filesystem (hard) link or rename.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub use ffi::channel::statuses::{ChannelStatusJoinError, ChannelStatuses};
 pub use ffi::observable_status::StatusesError;
 pub use ffi::channel::{
     CallError, Channel, ChannelJoinError, ChannelStatus, EventPayload, Events, EventsError,
+    LeaveError,
     ChannelError,
 };
 pub use ffi::io::error::IoError;


### PR DESCRIPTION
* Changes to `src/ffi/io/error.rs` are refactors for https://github.com/mozilla/uniffi-rs/issues/1968
* Exporting `LeaveError` required adding doc strings to the `LeaveError`.